### PR TITLE
add region/zone variables, make project creation optional

### DIFF
--- a/modules/gcp_project/main.tf
+++ b/modules/gcp_project/main.tf
@@ -1,0 +1,15 @@
+data "google_billing_account" "acct" {
+  count = var.create_project ? 1 : 0
+  billing_account = var.billing_account_id
+  open = true
+}
+
+resource "google_project" "gcp_project" {
+  count = var.create_project ? 1 : 0
+  name       = var.project_id
+  project_id = var.project_id
+  folder_id = var.folder_id
+  billing_account = data.google_billing_account.acct[count.index].id
+  auto_create_network = false
+  skip_delete = true
+}

--- a/modules/gcp_project/outputs.tf
+++ b/modules/gcp_project/outputs.tf
@@ -1,0 +1,3 @@
+output "project_id" {
+  value = var.create_project ? google_project.gcp_project[0].project_id : var.project_id
+}

--- a/modules/gcp_project/variables.tf
+++ b/modules/gcp_project/variables.tf
@@ -11,10 +11,10 @@ variable "project_id" {
 
 variable "billing_account_id" {
   type = string
-  description = "The billing account ID to be associated with the project. Required if create_project = true."
+  description = "The billing account ID to be associated with the project."
 }
 
 variable "folder_id" {
   type = string
-  description = "The folder_id for the location where the project should be created. Required if create_project = true."
+  description = "The folder_id for the location where the project should be created."
 }

--- a/modules/gcp_project/variables.tf
+++ b/modules/gcp_project/variables.tf
@@ -1,0 +1,20 @@
+variable "create_project" {
+  type = bool
+  description = "If true, creates the project and the project is managed by terraform. If false, it is assumed the project aready exists and it is not managed by terraform."
+  default = false
+}
+
+variable "project_id" {
+  type = string
+  description = "The project to set up."
+}
+
+variable "billing_account_id" {
+  type = string
+  description = "The billing account ID to be associated with the project. Required if create_project = true."
+}
+
+variable "folder_id" {
+  type = string
+  description = "The folder_id for the location where the project should be created. Required if create_project = true."
+}

--- a/samples/spring-postgres/main.tf
+++ b/samples/spring-postgres/main.tf
@@ -1,113 +1,94 @@
-locals {
-  project_id = var.project_id != "" ? var.project_id : "sample-spring-postgres${var.suffix}"
-  region  = "us-central1"
-  zone    = "us-central1-c"
-}
-
 provider "google" {
-  region = local.region
-  zone = local.zone
+  region = var.region
+  zone   = var.zone
 }
 
-data "google_billing_account" "acct" {
-  billing_account = var.billing_account_id
-  open = true
-}
-
-resource "google_project" "gcp_project" {
-  name       = local.project_id
-  project_id = local.project_id
-  folder_id = var.folder_id
-  billing_account = data.google_billing_account.acct.id
-  auto_create_network = false
-
-  # This project won't be deleted when you run `terraform destroy`
-  # To be able to reuse an existing project, run the following command before you run `terraform apply`
-  # $ terraform import google_project.gcp_project {YOUR_PROJECT_ID}
-  skip_delete = true
+module "gcp_project" {
+  source             = "../../modules/gcp_project"
+  create_project     = var.create_project
+  project_id         = var.project_id
+  billing_account_id = var.billing_account_id
+  folder_id          = var.folder_id
 }
 
 #####################
 # API setup - BEGIN #
 #####################
 resource "google_project_service" "compute_api" {
-  project = google_project.gcp_project.project_id
-  service = "compute.googleapis.com"
+  project            = module.gcp_project.project_id
+  service            = "compute.googleapis.com"
   disable_on_destroy = false
-  depends_on = [google_project.gcp_project]
 }
 
 resource "google_project_service" "storage_api" {
-  project = google_project.gcp_project.project_id
-  service = "storage.googleapis.com"
+  project            = module.gcp_project.project_id
+  service            = "storage.googleapis.com"
   disable_on_destroy = false
 }
 
 resource "google_project_service" "sqladmin_api" {
-  project = google_project.gcp_project.project_id
-  service = "sqladmin.googleapis.com"
+  project            = module.gcp_project.project_id
+  service            = "sqladmin.googleapis.com"
   disable_on_destroy = false
-  depends_on = [google_project.gcp_project]
 }
 ###################
 # API setup - END #
 ###################
 
 module "db" {
-  source  = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version = "12.0.0"
+  source               = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
+  version              = "12.0.0"
   name                 = "postgres-db"
   random_instance_name = true
   database_version     = "POSTGRES_9_6"
-  project_id           = google_project.gcp_project.project_id
-  zone                 = local.zone
-  region               = local.region
+  project_id           = module.gcp_project.project_id
+  zone                 = var.zone
+  region               = var.region
   tier                 = "db-custom-1-3840"
 
   deletion_protection = false
 
   ip_configuration = {
-    ipv4_enabled        = true
-    private_network     = null
-    require_ssl         = true
-    allocated_ip_range  = null
+    ipv4_enabled       = true
+    private_network    = null
+    require_ssl        = true
+    allocated_ip_range = null
     authorized_networks = [{
       name  = "sample-gcp-health-checkers-range"
       value = "130.211.0.0/28"
-    }
+      }
     ]
   }
   depends_on = [google_project_service.sqladmin_api]
 }
 
 module "staged_binary" {
-  source = "../../modules/binary_staging_storage_bucket"
-  project_id = google_project.gcp_project.project_id
-  region = local.region
-  bucket_name_prefix = google_project.gcp_project.project_id
-  file_name = "app.jar"
+  source        = "../../modules/binary_staging_storage_bucket"
+  project_id    = module.gcp_project.project_id
+  region        = var.region
+  file_name     = "app.jar"
   file_location = var.app_location
-  depends_on = [google_project_service.storage_api]
+  depends_on    = [google_project_service.storage_api]
 }
 
 data "template_file" "startup_script" {
   template = file("install_app.sh.tpl")
   vars = {
-    STAGED_BINARY = module.staged_binary.gs_url
-    DB_USERNAME = "default"
-    DB_PASSWORD = module.db.generated_user_password
-    DB_NAME = "default"
+    STAGED_BINARY      = module.staged_binary.gs_url
+    DB_USERNAME        = "default"
+    DB_PASSWORD        = module.db.generated_user_password
+    DB_NAME            = "default"
     DB_CONNECTION_NAME = module.db.instance_connection_name
-    DB_PROJECT_ID = google_project.gcp_project.project_id
+    DB_PROJECT_ID      = module.gcp_project.project_id
   }
 }
 
 module "app_cluster" {
-  source = "../../modules/http_accessible_mig"
-  project_id = google_project.gcp_project.project_id
-  region = local.region
-  deployment_name = "spring-app-"
-  startup_script = data.template_file.startup_script.rendered
+  source            = "../../modules/http_accessible_mig"
+  project_id        = module.gcp_project.project_id
+  region            = var.region
+  deployment_name   = "spring-app-"
+  startup_script    = data.template_file.startup_script.rendered
   health_check_path = "/getTuples"
-  depends_on = [google_project_service.compute_api, module.staged_binary, module.db]
+  depends_on        = [google_project_service.compute_api, module.staged_binary, module.db]
 }

--- a/samples/spring-postgres/outputs.tf
+++ b/samples/spring-postgres/outputs.tf
@@ -7,11 +7,11 @@ output "application_url" {
 }
 
 output "health_check_results" {
-  value = "Wait for VMs to show as healthy in this page: https://console.cloud.google.com/compute/instanceGroups/details/${local.region}/${module.app_cluster.name}?project=${local.project_id}"
+  value = "Wait for VMs to show as healthy in this page: https://console.cloud.google.com/compute/instanceGroups/details/${var.region}/${module.app_cluster.name}?project=${module.gcp_project.project_id}"
 }
 
 output "project_id" {
-  value = google_project.gcp_project.project_id
+  value = module.gcp_project.project_id
 }
 
 output "binary_gs_url" {

--- a/samples/spring-postgres/variables.tf
+++ b/samples/spring-postgres/variables.tf
@@ -1,37 +1,47 @@
-variable "suffix" {
-  type = string
-  description = "Override this value to create unique project names and prevent clashing."
-  default = ""
+variable "create_project" {
+  type        = bool
+  description = "If true, creates the project and the project is managed by terraform. If false, it is assumed the project aready exists and it is not managed by terraform."
 }
 
 variable "project_id" {
-  type = string
-  description = "Set this variable so the script will use the exact project_id you define"
-  default = ""
+  type        = string
+  description = "The project to deploy resources to."
 }
 
 variable "billing_account_id" {
-  type = string
-  description = "The billing account ID to be associated with the project."
+  type        = string
+  description = "The billing account ID to be associated with the project. Required if create_project = true."
 }
 
 variable "folder_id" {
-  type = string
+  type        = string
   description = "The folder_id for the location where the project should be created."
 }
 
+variable "region" {
+  type        = string
+  description = "GCP region to deploy resources to."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone to deploy resources to. Must be a zone in the chosen region."
+  default     = "us-central1-c"
+}
+
 variable "http_port" {
-  type = number
+  type        = number
   description = "The http port where the application will be listening"
-  default = 8080
+  default     = 8080
 }
 
 variable "app_location" {
-  type = string
+  type        = string
   description = "The path from where the Spring Cloud GCP PostgreSQL Sample jar should be copied"
 }
 
 variable "health_check_path" {
-  type = string
+  type    = string
   default = "/"
 }

--- a/samples/tomcat/outputs.tf
+++ b/samples/tomcat/outputs.tf
@@ -2,14 +2,14 @@ output "external_ip" {
   value = module.tomcat_cluster.external_ip
 }
 
-output "application_url" {
-  value = "http://${module.tomcat_cluster.external_ip}/sample"
+output "application_root_url" {
+  value = "http://${module.tomcat_cluster.external_ip}"
 }
 
 output "health_check_results" {
-  value = "Wait for VMs to show as healthy in this page: https://console.cloud.google.com/compute/instanceGroups/details/${local.region}/${module.tomcat_cluster.name}?project=${local.project_id}"
+  value = "Wait for VMs to show as healthy in this page: https://console.cloud.google.com/compute/instanceGroups/details/${var.region}/${module.tomcat_cluster.name}?project=${module.gcp_project.project_id}"
 }
 
 output "project_id" {
-  value = google_project.gcp_project.project_id
+  value = module.gcp_project.project_id
 }

--- a/samples/tomcat/variables.tf
+++ b/samples/tomcat/variables.tf
@@ -1,21 +1,31 @@
-variable "suffix" {
-  type = string
-  description = "Override this value to create unique project names and prevent clashing."
-  default = ""
+variable "create_project" {
+  type        = bool
+  description = "If true, creates the project and the project is managed by terraform. If false, it is assumed the project aready exists and it is not managed by terraform."
 }
 
 variable "project_id" {
-  type = string
-  description = "Set this variable so the script will use the exact project_id you define"
-  default = ""
+  type        = string
+  description = "The project to deploy resources to."
 }
 
 variable "billing_account_id" {
-  type = string
-  description = "The billing account ID to be associated with the project."
+  type        = string
+  description = "The billing account ID to be associated with the project. Required if create_project = true."
 }
 
 variable "folder_id" {
-  type = string
+  type        = string
   description = "The folder_id for the location where the project should be created."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region to deploy resources to."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone to deploy resources to. Must be a zone in the chosen region."
+  default     = "us-central1-c"
 }


### PR DESCRIPTION
- Add region and zone variables so people who are far away from us-central1 are not forced to use it.
- Optionally create project, because many don't have permission to do that.